### PR TITLE
Feature - Delegate hydrator

### DIFF
--- a/src/Incoming/Hydrator/AbstractDelegateHydrator.php
+++ b/src/Incoming/Hydrator/AbstractDelegateHydrator.php
@@ -82,4 +82,19 @@ abstract class AbstractDelegateHydrator implements HydratorInterface
 
         return $delegate;
     }
+
+    /**
+     * The delegate hydrate method
+     *
+     * This doc-block and commented out abstract method is provided here to show
+     * what the delegate method signature WOULD be if PHP allowed the proper
+     * typing support to enable a generic definition in this manner
+     *
+     * See the class description for more info
+     *
+     * @param IncomingDataType $incoming The input data
+     * @param ModelType $model The model to hydrate
+     * @return ModelType The hydrated model
+     */
+    // abstract protected function hydrateModel(IncomingDataType $incoming, ModelType $model);
 }

--- a/src/Incoming/Hydrator/AbstractDelegateHydrator.php
+++ b/src/Incoming/Hydrator/AbstractDelegateHydrator.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Incoming
+ *
+ * @author    Trevor Suarez (Rican7)
+ * @copyright (c) Trevor Suarez
+ * @link      https://github.com/Rican7/incoming
+ * @license   MIT
+ */
+
+namespace Incoming\Hydrator;
+
+use Incoming\Hydrator\Exception\InvalidDelegateException;
+
+/**
+ * AbstractDelegateHydrator
+ *
+ * TODO: Document and explain the reasoning for this class to exist
+ */
+abstract class AbstractDelegateHydrator implements HydratorInterface
+{
+
+    /**
+     * Constants
+     */
+
+    /**
+     * The name of the default delegate method
+     *
+     * @type string
+     */
+    const DEFAULT_DELEGATE_METHOD_NAME = 'hydrateModel';
+
+
+    /**
+     * Methods
+     */
+
+    /**
+     * {@inheritdoc}
+     *
+     * @param mixed $incoming The input data
+     * @param mixed $model The model to hydrate
+     * @return mixed The hydrated model
+     */
+    public function hydrate($incoming, $model)
+    {
+        return call_user_func(
+            $this->getDelegate(),
+            $incoming,
+            $model
+        );
+    }
+
+    /**
+     * Get the delegate hydration callable
+     *
+     * @return callable The delegate hydrator callable
+     */
+    protected function getDelegate()
+    {
+        $delegate = [$this, static::DEFAULT_DELEGATE_METHOD_NAME];
+
+        if (!is_callable($delegate, false, $callable_name)) {
+            // TODO: Throw exception
+        }
+
+        return $delegate;
+    }
+}

--- a/src/Incoming/Hydrator/AbstractDelegateHydrator.php
+++ b/src/Incoming/Hydrator/AbstractDelegateHydrator.php
@@ -15,7 +15,20 @@ use Incoming\Hydrator\Exception\InvalidDelegateException;
 /**
  * AbstractDelegateHydrator
  *
- * TODO: Document and explain the reasoning for this class to exist
+ * An abstract hydrator that allows for the hydration to be delegated to another
+ * callable. By default, a named method is attempted to be found, but any
+ * callable could be returned through overrides.
+ *
+ * This enables a lot of interesting uses, most notably this allows hydrators to
+ * be created that have strongly type-hinted hydration arguments while still
+ * perfectly satisfying the `HydratorInterface`. Essentially this allows the
+ * bypassing of the type variance rules enforced by PHP in a way that provides a
+ * generics-like definition. Ultimately, if/when PHP gets generics this will no
+ * longer be necessary, as one could simply implement a hydrator using typed
+ * arguments like: `HydratorInterface<IncomingDataType, ModelType>`
+ *
+ * @link http://en.wikipedia.org/wiki/Covariance_and_contravariance_(computer_science)
+ * @link http://en.wikipedia.org/wiki/Generic_programming
  */
 abstract class AbstractDelegateHydrator implements HydratorInterface
 {
@@ -54,6 +67,8 @@ abstract class AbstractDelegateHydrator implements HydratorInterface
 
     /**
      * Get the delegate hydration callable
+     *
+     * Override this method if a custom delegate is desired
      *
      * @return callable The delegate hydrator callable
      */

--- a/src/Incoming/Hydrator/AbstractDelegateHydrator.php
+++ b/src/Incoming/Hydrator/AbstractDelegateHydrator.php
@@ -62,7 +62,7 @@ abstract class AbstractDelegateHydrator implements HydratorInterface
         $delegate = [$this, static::DEFAULT_DELEGATE_METHOD_NAME];
 
         if (!is_callable($delegate, false, $callable_name)) {
-            // TODO: Throw exception
+            throw InvalidDelegateException::forNonCallable($callable_name);
         }
 
         return $delegate;

--- a/src/Incoming/Hydrator/Exception/InvalidDelegateException.php
+++ b/src/Incoming/Hydrator/Exception/InvalidDelegateException.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Incoming
+ *
+ * @author    Trevor Suarez (Rican7)
+ * @copyright (c) Trevor Suarez
+ * @link      https://github.com/Rican7/incoming
+ * @license   MIT
+ */
+
+namespace Incoming\Hydrator\Exception;
+
+use BadMethodCallException;
+use Exception;
+
+/**
+ * InvalidDelegateException
+ *
+ * An exception to be thrown when a delegate method, function, or callback is
+ * provided to a caller
+ */
+class InvalidDelegateException extends BadMethodCallException
+{
+
+    /**
+     * Constants
+     */
+
+    /**
+     * @type string
+     */
+    const DEFAULT_MESSAGE = 'Invalid delegate';
+
+    /**
+     * The exception code for when a delegate isn't callable
+     *
+     * @type int
+     */
+    const CODE_FOR_NON_CALLABLE = 1;
+
+    /**
+     * The message extension for when a delegate isn't callable
+     *
+     * @type string
+     */
+    const MESSAGE_EXTENSION_FOR_NON_CALLABLE = ' is unable to be called';
+
+    /**
+     * The message extension format for when a delegate's name is provided
+     *
+     * @type string
+     */
+    const MESSAGE_EXTENSION_NAME_FORMAT = ' named `%s`';
+
+
+    /**
+     * Properties
+     */
+
+    /**
+     * @type string
+     */
+    protected $message = self::DEFAULT_MESSAGE;
+
+
+    /**
+     * Methods
+     */
+
+    /**
+     * Create an exception instance for a delegate that isn't callable
+     *
+     * @param mixed|null $name The name of the delegate
+     * @param int $code The exception code
+     * @param Exception|null $previous A previous exception used for chaining
+     * @return InvalidDelegateException The newly created exception
+     */
+    public static function forNonCallable($name = null, $code = self::CODE_FOR_NON_CALLABLE, Exception $previous = null)
+    {
+        $message = self::DEFAULT_MESSAGE;
+
+        if (null !== $name) {
+            $message .= sprintf(
+                self::MESSAGE_EXTENSION_NAME_FORMAT,
+                $name
+            );
+        }
+
+        $message .= self::MESSAGE_EXTENSION_FOR_NON_CALLABLE;
+
+        return new static($message, $code, $previous);
+    }
+}

--- a/src/Incoming/Hydrator/Exception/InvalidDelegateException.php
+++ b/src/Incoming/Hydrator/Exception/InvalidDelegateException.php
@@ -10,16 +10,16 @@
 
 namespace Incoming\Hydrator\Exception;
 
-use BadMethodCallException;
+use BadFunctionCallException;
 use Exception;
 
 /**
  * InvalidDelegateException
  *
- * An exception to be thrown when a delegate method, function, or callback is
- * provided to a caller
+ * An exception to be thrown when an invalid delegate method, function, or
+ * callback is provided to a caller
  */
-class InvalidDelegateException extends BadMethodCallException
+class InvalidDelegateException extends BadFunctionCallException
 {
 
     /**

--- a/tests/Incoming/Test/Hydrator/AbstractDelegateHydratorTest.php
+++ b/tests/Incoming/Test/Hydrator/AbstractDelegateHydratorTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Incoming
+ *
+ * @author    Trevor Suarez (Rican7)
+ * @copyright (c) Trevor Suarez
+ * @link      https://github.com/Rican7/incoming
+ * @license   MIT
+ */
+
+namespace Incoming\Test\Hydrator;
+
+use DateTime;
+use Incoming\Hydrator\AbstractDelegateHydrator;
+use Incoming\Structure\Map;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * AbstractDelegateHydratorTest
+ */
+class AbstractDelegateHydratorTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Helpers
+     */
+
+    private function getMockDelegateHydrator(callable $delegate)
+    {
+        $mock = $this->getMockBuilder('Incoming\Hydrator\AbstractDelegateHydrator')
+            ->setMethods([AbstractDelegateHydrator::DEFAULT_DELEGATE_METHOD_NAME])
+            ->getMock();
+
+        $mock->expects($this->any())
+            ->method(AbstractDelegateHydrator::DEFAULT_DELEGATE_METHOD_NAME)
+            ->will($this->returnCallback($delegate));
+
+        return $mock;
+    }
+
+
+    /**
+     * Tests
+     */
+
+    public function testHydrate()
+    {
+        $test_input_data = Map::fromArray([
+            'year' => 1983,
+            'month' => 1,
+            'day' => 2,
+        ]);
+        $test_model = new DateTime();
+
+        $test_delegate_callable = function (Map $incoming, DateTime $model) {
+            $model->setDate(
+                $incoming->get('year'),
+                $incoming->get('month'),
+                $incoming->get('day')
+            );
+
+            return $model;
+        };
+
+        $test_hydrator = $this->getMockDelegateHydrator($test_delegate_callable);
+
+        $hydrated = $test_hydrator->hydrate($test_input_data, $test_model);
+
+        $this->assertEquals($test_model, $hydrated);
+        $this->assertSame($test_input_data['year'], (int) $hydrated->format('Y'));
+        $this->assertSame($test_input_data['month'], (int) $hydrated->format('m'));
+        $this->assertSame($test_input_data['day'], (int) $hydrated->format('j'));
+    }
+}

--- a/tests/Incoming/Test/Hydrator/AbstractDelegateHydratorTest.php
+++ b/tests/Incoming/Test/Hydrator/AbstractDelegateHydratorTest.php
@@ -13,6 +13,7 @@ namespace Incoming\Test\Hydrator;
 use DateTime;
 use Incoming\Hydrator\AbstractDelegateHydrator;
 use Incoming\Structure\Map;
+use Incoming\Test\Hydrator\MockDelegateHydrator;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -70,5 +71,28 @@ class AbstractDelegateHydratorTest extends PHPUnit_Framework_TestCase
         $this->assertSame($test_input_data['year'], (int) $hydrated->format('Y'));
         $this->assertSame($test_input_data['month'], (int) $hydrated->format('m'));
         $this->assertSame($test_input_data['day'], (int) $hydrated->format('j'));
+    }
+
+    /**
+     * @expectedException Incoming\Hydrator\Exception\InvalidDelegateException
+     */
+    public function testHydrateWithNonCallableThrowsException()
+    {
+        $mock_hydrator = new MockDelegateHydrator();
+
+        $mock_hydrator->hydrate([], new DateTime());
+    }
+
+    /**
+     * @expectedException PHPUnit_Framework_Error
+     */
+    public function testHydrateWithImproperTypesCausesTypeError()
+    {
+        $test_delegate_callable = function (Map $incoming, DateTime $model) {
+        };
+
+        $test_hydrator = $this->getMockDelegateHydrator($test_delegate_callable);
+
+        $test_hydrator->hydrate([], new DateTime());
     }
 }

--- a/tests/Incoming/Test/Hydrator/Exception/InvalidDelegateExceptionTest.php
+++ b/tests/Incoming/Test/Hydrator/Exception/InvalidDelegateExceptionTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Incoming
+ *
+ * @author    Trevor Suarez (Rican7)
+ * @copyright (c) Trevor Suarez
+ * @link      https://github.com/Rican7/incoming
+ * @license   MIT
+ */
+
+namespace Incoming\Test\Hydrator\Exception;
+
+use Exception;
+use Incoming\Hydrator\Exception\InvalidDelegateException;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * InvalidDelegateExceptionTest
+ */
+class InvalidDelegateExceptionTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testForNonCallable()
+    {
+        $exception = InvalidDelegateException::forNonCallable();
+
+        $this->assertTrue($exception instanceof Exception);
+        $this->assertTrue($exception instanceof InvalidDelegateException);
+        $this->assertSame(InvalidDelegateException::CODE_FOR_NON_CALLABLE, $exception->getCode());
+    }
+
+    public function testForNonCallableWithName()
+    {
+        $non_callable_name = 'someNonExistentFunction';
+
+        $exception = InvalidDelegateException::forNonCallable($non_callable_name);
+
+        $this->assertTrue($exception instanceof Exception);
+        $this->assertTrue($exception instanceof InvalidDelegateException);
+        $this->assertSame(InvalidDelegateException::CODE_FOR_NON_CALLABLE, $exception->getCode());
+    }
+
+    public function testForNonCallableWithNameAndExceptionArgs()
+    {
+        $non_callable_name = 'someNonExistentFunction';
+        $code = 1337;
+        $previous = new Exception();
+
+        $exception = InvalidDelegateException::forNonCallable($non_callable_name, $code, $previous);
+
+        $this->assertTrue($exception instanceof Exception);
+        $this->assertTrue($exception instanceof InvalidDelegateException);
+        $this->assertSame($code, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Incoming/Test/Hydrator/MockDelegateHydrator.php
+++ b/tests/Incoming/Test/Hydrator/MockDelegateHydrator.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Incoming
+ *
+ * @author    Trevor Suarez (Rican7)
+ * @copyright (c) Trevor Suarez
+ * @link      https://github.com/Rican7/incoming
+ * @license   MIT
+ */
+
+namespace Incoming\Test\Hydrator;
+
+use Incoming\Hydrator\AbstractDelegateHydrator;
+
+/**
+ * MockDelegateHydrator
+ */
+class MockDelegateHydrator extends AbstractDelegateHydrator
+{
+}


### PR DESCRIPTION
This PR implements an abstract hydrator that allows for the hydration to be delegated to another callable. By default, a named method is attempted to be found, but any callable could be returned through overrides.

This enables a lot of interesting uses, most notably this allows hydrators to be created that have strongly type-hinted hydration arguments while still perfectly satisfying the `HydratorInterface`. Essentially this allows the bypassing of the [type variance][wiki-type-variance] rules enforced by PHP in a way that provides a generics-like definition. Ultimately, if/when PHP gets [generics][wiki-generic-programming] this will no longer be necessary, as one could simply implement a hydrator using typed arguments like: `HydratorInterface<IncomingDataType, ModelType>`.

This idea was born out of a frustration with being unable to properly implement the `HydratorInterface` in an application I was using **Incoming** in without dropping the type hints:

![4-1-2015-12-09-18-am-b5b0](https://cloud.githubusercontent.com/assets/742384/6934468/5ec46a2e-d803-11e4-811a-e5d266724cb3.png)



[wiki-type-variance]: http://en.wikipedia.org/wiki/Covariance_and_contravariance_(computer_science)
[wiki-generic-programming]: http://en.wikipedia.org/wiki/Generic_programming