### PR TITLE
Bugfix - PHP 7 TypeError expected

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.5",
-        "phpunit/php-code-coverage": "~2.0",
+        "phpunit/phpunit": "^4.7.4",
+        "phpunit/php-code-coverage": "^2.0",
         "squizlabs/php_codesniffer": "~2.3"
     },
     "autoload": {

--- a/tests/Incoming/Test/Hydrator/AbstractDelegateHydratorTest.php
+++ b/tests/Incoming/Test/Hydrator/AbstractDelegateHydratorTest.php
@@ -83,11 +83,14 @@ class AbstractDelegateHydratorTest extends PHPUnit_Framework_TestCase
         $mock_hydrator->hydrate([], new DateTime());
     }
 
-    /**
-     * @expectedException PHPUnit_Framework_Error
-     */
     public function testHydrateWithImproperTypesCausesTypeError()
     {
+        if (0 <= version_compare(PHP_VERSION, '7')) {
+            $this->setExpectedException('TypeError');
+        } else {
+            $this->setExpectedException('PHPUnit_Framework_Error');
+        }
+
         $test_delegate_callable = function (Map $incoming, DateTime $model) {
         };
 


### PR DESCRIPTION
[PHP 7 has been failing on a single unit test][php7-failed-test-typerror], due to the way that types are checked and the errors are handled in the newer runtime. Unfortunately, the way it was handled [was sub-par until a recent change][php-rfc-throwable]. Now with the newer type hierarchy and [proper PHPUnit support][phpunit-commit-throwable-support], I can finally fix the test to pass under PHP 7.

I'm going to be leaning on Travis-CI for this one pretty hard since I don't have a proper PHP 7 setup on my local machine...


[php7-failed-test-typerror]: https://travis-ci.org/Rican7/incoming/jobs/57129773#L198
[php-rfc-throwable]: https://wiki.php.net/rfc/throwable-interface
[phpunit-commit-throwable-support]: https://github.com/sebastianbergmann/phpunit/commit/16b5b198d4b73e6713eae5ffbd6da2f66b0e2ea2