### PR TITLE
Feature - PHP 7 Upgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 
 language: php
 php:
-  - 5.4
-  - 5.5
-  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
   - nightly
   - hhvm
 

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         "source": "https://github.com/Rican7/incoming"
     },
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=7.0.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.7.4",
-        "phpunit/php-code-coverage": "^2.0",
-        "squizlabs/php_codesniffer": "~2.3"
+        "phpunit/phpunit": "^6.5",
+        "phpunit/php-code-coverage": "^5.3",
+        "squizlabs/php_codesniffer": "^3.2"
     },
     "autoload": {
         "psr-4": {"Incoming\\": "src/Incoming/"}

--- a/src/Incoming/Hydrator/AbstractDelegateHydrator.php
+++ b/src/Incoming/Hydrator/AbstractDelegateHydrator.php
@@ -8,13 +8,13 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Hydrator;
 
 use Incoming\Hydrator\Exception\InvalidDelegateException;
 
 /**
- * AbstractDelegateHydrator
- *
  * An abstract hydrator that allows for the hydration to be delegated to another
  * callable. By default, a named method is attempted to be found, but any
  * callable could be returned through overrides.
@@ -40,7 +40,7 @@ abstract class AbstractDelegateHydrator implements HydratorInterface
     /**
      * The name of the default delegate method
      *
-     * @type string
+     * @var string
      */
     const DEFAULT_DELEGATE_METHOD_NAME = 'hydrateModel';
 
@@ -72,7 +72,7 @@ abstract class AbstractDelegateHydrator implements HydratorInterface
      *
      * @return callable The delegate hydrator callable
      */
-    protected function getDelegate()
+    protected function getDelegate(): callable
     {
         $delegate = [$this, static::DEFAULT_DELEGATE_METHOD_NAME];
 
@@ -96,5 +96,5 @@ abstract class AbstractDelegateHydrator implements HydratorInterface
      * @param ModelType $model The model to hydrate
      * @return ModelType The hydrated model
      */
-    // abstract protected function hydrateModel(IncomingDataType $incoming, ModelType $model);
+    // abstract protected function hydrateModel(IncomingDataType $incoming, ModelType $model): ModelType;
 }

--- a/src/Incoming/Hydrator/Exception/InvalidDelegateException.php
+++ b/src/Incoming/Hydrator/Exception/InvalidDelegateException.php
@@ -8,14 +8,14 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Hydrator\Exception;
 
 use BadFunctionCallException;
 use Exception;
 
 /**
- * InvalidDelegateException
- *
  * An exception to be thrown when an invalid delegate method, function, or
  * callback is provided to a caller
  */
@@ -27,28 +27,28 @@ class InvalidDelegateException extends BadFunctionCallException
      */
 
     /**
-     * @type string
+     * @var string
      */
     const DEFAULT_MESSAGE = 'Invalid delegate';
 
     /**
      * The exception code for when a delegate isn't callable
      *
-     * @type int
+     * @var int
      */
     const CODE_FOR_NON_CALLABLE = 1;
 
     /**
      * The message extension for when a delegate isn't callable
      *
-     * @type string
+     * @var string
      */
     const MESSAGE_EXTENSION_FOR_NON_CALLABLE = ' is unable to be called';
 
     /**
      * The message extension format for when a delegate's name is provided
      *
-     * @type string
+     * @var string
      */
     const MESSAGE_EXTENSION_NAME_FORMAT = ' named `%s`';
 
@@ -58,7 +58,7 @@ class InvalidDelegateException extends BadFunctionCallException
      */
 
     /**
-     * @type string
+     * @var string
      */
     protected $message = self::DEFAULT_MESSAGE;
 
@@ -73,10 +73,13 @@ class InvalidDelegateException extends BadFunctionCallException
      * @param mixed|null $name The name of the delegate
      * @param int $code The exception code
      * @param Exception|null $previous A previous exception used for chaining
-     * @return InvalidDelegateException The newly created exception
+     * @return static The newly created exception
      */
-    public static function forNonCallable($name = null, $code = self::CODE_FOR_NON_CALLABLE, Exception $previous = null)
-    {
+    public static function forNonCallable(
+        $name = null,
+        $code = self::CODE_FOR_NON_CALLABLE,
+        Exception $previous = null
+    ): self {
         $message = self::DEFAULT_MESSAGE;
 
         if (null !== $name) {

--- a/src/Incoming/Hydrator/Exception/InvalidDelegateException.php
+++ b/src/Incoming/Hydrator/Exception/InvalidDelegateException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace Incoming\Hydrator\Exception;
 
 use BadFunctionCallException;
-use Exception;
+use Throwable;
 
 /**
  * An exception to be thrown when an invalid delegate method, function, or
@@ -70,15 +70,15 @@ class InvalidDelegateException extends BadFunctionCallException
     /**
      * Create an exception instance for a delegate that isn't callable
      *
-     * @param mixed|null $name The name of the delegate
+     * @param string|null $name The name of the delegate
      * @param int $code The exception code
-     * @param Exception|null $previous A previous exception used for chaining
+     * @param Throwable|null $previous A previous exception used for chaining
      * @return static The newly created exception
      */
     public static function forNonCallable(
-        $name = null,
-        $code = self::CODE_FOR_NON_CALLABLE,
-        Exception $previous = null
+        string $name = null,
+        int $code = self::CODE_FOR_NON_CALLABLE,
+        Throwable $previous = null
     ): self {
         $message = self::DEFAULT_MESSAGE;
 

--- a/src/Incoming/Hydrator/Exception/UnresolvableHydratorException.php
+++ b/src/Incoming/Hydrator/Exception/UnresolvableHydratorException.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace Incoming\Hydrator\Exception;
 
-use Exception;
+use Throwable;
 use UnexpectedValueException;
 
 /**
@@ -74,13 +74,13 @@ class UnresolvableHydratorException extends UnexpectedValueException
      *
      * @param mixed $model The model to hydrate
      * @param int $code The exception code
-     * @param Exception|null $previous A previous exception used for chaining
+     * @param Throwable|null $previous A previous exception used for chaining
      * @return static The newly created exception
      */
     public static function forModel(
         $model,
-        $code = self::CODE_FOR_MODEL,
-        Exception $previous = null
+        int $code = self::CODE_FOR_MODEL,
+        Throwable $previous = null
     ): self {
         $message = self::DEFAULT_MESSAGE . self::MESSAGE_EXTENSION_FOR_MODEL;
 

--- a/src/Incoming/Hydrator/Exception/UnresolvableHydratorException.php
+++ b/src/Incoming/Hydrator/Exception/UnresolvableHydratorException.php
@@ -8,14 +8,14 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Hydrator\Exception;
 
 use Exception;
 use UnexpectedValueException;
 
 /**
- * UnresolvableHydratorException
- *
  * An exception to be thrown when a hydrator can't be resolved, whether by
  * automatic lookup or not, and usually for a given model
  */
@@ -27,14 +27,14 @@ class UnresolvableHydratorException extends UnexpectedValueException
      */
 
     /**
-     * @type string
+     * @var string
      */
     const DEFAULT_MESSAGE = 'Unable to resolve a hydrator';
 
     /**
      * The exception code for when a model is used as the resolver argument
      *
-     * @type int
+     * @var int
      */
     const CODE_FOR_MODEL = 1;
 
@@ -42,14 +42,14 @@ class UnresolvableHydratorException extends UnexpectedValueException
      * The message extension (appended to the default message) for when a model
      * is used as the hydrator resolver argument
      *
-     * @type string
+     * @var string
      */
     const MESSAGE_EXTENSION_FOR_MODEL = ' for the given model';
 
     /**
      * The message extension format for providing type information
      *
-     * @type string
+     * @var string
      */
     const MESSAGE_EXTENSION_TYPE_FORMAT = ' of type `%s`';
 
@@ -59,7 +59,7 @@ class UnresolvableHydratorException extends UnexpectedValueException
      */
 
     /**
-     * @type string
+     * @var string
      */
     protected $message = self::DEFAULT_MESSAGE;
 
@@ -75,10 +75,13 @@ class UnresolvableHydratorException extends UnexpectedValueException
      * @param mixed $model The model to hydrate
      * @param int $code The exception code
      * @param Exception|null $previous A previous exception used for chaining
-     * @return UnresolvableHydratorException The newly created exception
+     * @return static The newly created exception
      */
-    public static function forModel($model, $code = self::CODE_FOR_MODEL, Exception $previous = null)
-    {
+    public static function forModel(
+        $model,
+        $code = self::CODE_FOR_MODEL,
+        Exception $previous = null
+    ): self {
         $message = self::DEFAULT_MESSAGE . self::MESSAGE_EXTENSION_FOR_MODEL;
 
         $message .= sprintf(

--- a/src/Incoming/Hydrator/HydratorFactoryInterface.php
+++ b/src/Incoming/Hydrator/HydratorFactoryInterface.php
@@ -8,11 +8,11 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Hydrator;
 
 /**
- * HydratorFactoryInterface
- *
  * Defines an interface for factory implementations that build a `Hydrator` from
  * a given data model
  *

--- a/src/Incoming/Hydrator/HydratorFactoryInterface.php
+++ b/src/Incoming/Hydrator/HydratorFactoryInterface.php
@@ -28,5 +28,5 @@ interface HydratorFactoryInterface
      * @param mixed $model The model to hydrate
      * @return HydratorInterface A hydrator capable of hydrating the given model
      */
-    public function buildForModel($model);
+    public function buildForModel($model): HydratorInterface;
 }

--- a/src/Incoming/Hydrator/HydratorInterface.php
+++ b/src/Incoming/Hydrator/HydratorInterface.php
@@ -8,11 +8,11 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Hydrator;
 
 /**
- * HydratorInterface
- *
  * Defines an interface for "hydrating" a well-defined, consistent data model
  * from a loose input structure
  */

--- a/src/Incoming/Processor.php
+++ b/src/Incoming/Processor.php
@@ -8,6 +8,8 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming;
 
 use Incoming\Hydrator\Exception\UnresolvableHydratorException;
@@ -17,8 +19,6 @@ use Incoming\Transformer\StructureBuilderTransformer;
 use Incoming\Transformer\TransformerInterface;
 
 /**
- * Processor
- *
  * A default implementation of the `ProcessorInterface` for processing input
  * data with an optional input transformation phase and automatic hydrator
  * resolution
@@ -33,14 +33,14 @@ class Processor implements ProcessorInterface
     /**
      * An input transformer to pre-process the input data before hydration
      *
-     * @type TransformerInterface
+     * @var TransformerInterface
      */
     private $input_transformer;
 
     /**
      * A factory for building hydrators for a given model
      *
-     * @type HydratorFactoryInterface
+     * @var HydratorFactoryInterface
      */
     private $hydrator_factory;
 
@@ -64,7 +64,7 @@ class Processor implements ProcessorInterface
      *
      * @return TransformerInterface The input transformer
      */
-    public function getInputTransformer()
+    public function getInputTransformer(): TransformerInterface
     {
         return $this->input_transformer;
     }
@@ -73,9 +73,9 @@ class Processor implements ProcessorInterface
      * Set the input transformer
      *
      * @param TransformerInterface $input_transformer The input transformer
-     * @return Processor This instance
+     * @return $this This instance
      */
-    public function setInputTransformer(TransformerInterface $input_transformer)
+    public function setInputTransformer(TransformerInterface $input_transformer): self
     {
         $this->input_transformer = $input_transformer;
 
@@ -85,7 +85,7 @@ class Processor implements ProcessorInterface
     /**
      * Get the hydrator factory
      *
-     * @return HydratorFactoryInterface The hydrator factory
+     * @return HydratorFactoryInterface|null The hydrator factory
      */
     public function getHydratorFactory()
     {
@@ -96,9 +96,9 @@ class Processor implements ProcessorInterface
      * Set the hydrator factory
      *
      * @param HydratorFactoryInterface|null $hydrator_factory The hydrator factory
-     * @return Processor This instance
+     * @return $this This instance
      */
-    public function setHydratorFactory(HydratorFactoryInterface $hydrator_factory = null)
+    public function setHydratorFactory(HydratorFactoryInterface $hydrator_factory = null): self
     {
         $this->hydrator_factory = $hydrator_factory;
 
@@ -113,7 +113,7 @@ class Processor implements ProcessorInterface
      *
      * @param mixed $input_data The input data
      * @param mixed $model The model to hydrate
-     * * @param HydratorInterface|null $hydrator The hydrator to use
+     * @param HydratorInterface|null $hydrator The hydrator to use
      * @return mixed The hydrated model
      */
     public function process($input_data, $model, HydratorInterface $hydrator = null)
@@ -146,7 +146,7 @@ class Processor implements ProcessorInterface
      *  the given model
      * @return HydratorInterface The resulting hydrator
      */
-    protected function getHydratorForModel($model)
+    protected function getHydratorForModel($model): HydratorInterface
     {
         if (null === $this->hydrator_factory) {
             throw UnresolvableHydratorException::forModel($model);

--- a/src/Incoming/Processor.php
+++ b/src/Incoming/Processor.php
@@ -53,10 +53,14 @@ class Processor implements ProcessorInterface
      * Constructor
      *
      * @param TransformerInterface|null $input_transformer The input transformer
+     * @param HydratorFactoryInterface|null $hydrator_factory A hydrator factory
      */
-    public function __construct(TransformerInterface $input_transformer = null)
-    {
+    public function __construct(
+        TransformerInterface $input_transformer = null,
+        HydratorFactoryInterface $hydrator_factory = null
+    ) {
         $this->input_transformer = $input_transformer ?: new StructureBuilderTransformer();
+        $this->hydrator_factory = $hydrator_factory;
     }
 
     /**

--- a/src/Incoming/ProcessorInterface.php
+++ b/src/Incoming/ProcessorInterface.php
@@ -8,13 +8,13 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming;
 
 use Incoming\Hydrator\HydratorInterface;
 
 /**
- * ProcessorInterface
- *
  * Defines an interface for processing loose input data into a hydrated model,
  * using a given hydrator
  */

--- a/src/Incoming/Structure/Exception/InvalidStructuralTypeException.php
+++ b/src/Incoming/Structure/Exception/InvalidStructuralTypeException.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
 
 namespace Incoming\Structure\Exception;
 
-use Exception;
 use InvalidArgumentException;
+use Throwable;
 
 /**
  * An exception to be thrown when an invalid type is given to a factory or
@@ -60,10 +60,10 @@ class InvalidStructuralTypeException extends InvalidArgumentException
      *
      * @param mixed $value The value to inspect type information of
      * @param int $code The exception code
-     * @param Exception|null $previous A previous exception used for chaining
+     * @param Throwable|null $previous A previous exception used for chaining
      * @return static The newly created exception
      */
-    public static function withTypeInfo($value, $code = 0, Exception $previous = null): self
+    public static function withTypeInfo($value, int $code = 0, Throwable $previous = null): self
     {
         $message = self::DEFAULT_MESSAGE;
 

--- a/src/Incoming/Structure/Exception/InvalidStructuralTypeException.php
+++ b/src/Incoming/Structure/Exception/InvalidStructuralTypeException.php
@@ -8,14 +8,14 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Structure\Exception;
 
 use Exception;
 use InvalidArgumentException;
 
 /**
- * InvalidStructuralTypeException
- *
  * An exception to be thrown when an invalid type is given to a factory or
  * receiver that expects a type that is convertible or usable as structured data
  */
@@ -27,14 +27,14 @@ class InvalidStructuralTypeException extends InvalidArgumentException
      */
 
     /**
-     * @type string
+     * @var string
      */
     const DEFAULT_MESSAGE = 'Invalid structural type';
 
     /**
      * The message extension format for providing type information
      *
-     * @type string
+     * @var string
      */
     const MESSAGE_EXTENSION_TYPE_FORMAT = ' `%s`';
 
@@ -44,7 +44,7 @@ class InvalidStructuralTypeException extends InvalidArgumentException
      */
 
     /**
-     * @type string
+     * @var string
      */
     protected $message = self::DEFAULT_MESSAGE;
 
@@ -61,9 +61,9 @@ class InvalidStructuralTypeException extends InvalidArgumentException
      * @param mixed $value The value to inspect type information of
      * @param int $code The exception code
      * @param Exception|null $previous A previous exception used for chaining
-     * @return InvalidStructuralTypeException The newly created exception
+     * @return static The newly created exception
      */
-    public static function withTypeInfo($value, $code = 0, Exception $previous = null)
+    public static function withTypeInfo($value, $code = 0, Exception $previous = null): self
     {
         $message = self::DEFAULT_MESSAGE;
 

--- a/src/Incoming/Structure/Exception/ReadOnlyException.php
+++ b/src/Incoming/Structure/Exception/ReadOnlyException.php
@@ -8,14 +8,14 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Structure\Exception;
 
 use BadMethodCallException;
 use Exception;
 
 /**
- * ReadOnlyException
- *
  * An exception to be thrown when an attempt is made to modify a read-only
  * value, property, or state
  */
@@ -27,21 +27,21 @@ class ReadOnlyException extends BadMethodCallException
      */
 
     /**
-     * @type string
+     * @var string
      */
     const DEFAULT_MESSAGE = 'Illegal modification attempt';
 
     /**
      * The exception code for an exception with an attribute context
      *
-     * @type int
+     * @var int
      */
     const CODE_FOR_ATTRIBUTE = 1;
 
     /**
      * The message extension format for providing an attribute context's info
      *
-     * @type string
+     * @var string
      */
     const MESSAGE_EXTENSION_FOR_ATTRIBUTE_FORMAT = ' for attribute `%s`';
 
@@ -49,7 +49,7 @@ class ReadOnlyException extends BadMethodCallException
      * The message extension format for providing an attribute's value info
      * in addition to the attribute's context
      *
-     * @type string
+     * @var string
      */
     const MESSAGE_EXTENSION_FOR_ATTRIBUTE_WITH_VALUE_FORMAT = ' and value `%s`';
 
@@ -59,7 +59,7 @@ class ReadOnlyException extends BadMethodCallException
      */
 
     /**
-     * @type string
+     * @var string
      */
     protected $message = self::DEFAULT_MESSAGE;
 
@@ -75,14 +75,14 @@ class ReadOnlyException extends BadMethodCallException
      * @param mixed|null $value The value attempted to be set
      * @param int $code The exception code
      * @param Exception|null $previous A previous exception used for chaining
-     * @return ReadOnlyException The newly created exception
+     * @return static The newly created exception
      */
     public static function forAttribute(
         $name,
         $value = null,
         $code = self::CODE_FOR_ATTRIBUTE,
         Exception $previous = null
-    ) {
+    ): self {
         $message = self::DEFAULT_MESSAGE;
 
         if (null !== $value) {

--- a/src/Incoming/Structure/Exception/ReadOnlyException.php
+++ b/src/Incoming/Structure/Exception/ReadOnlyException.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace Incoming\Structure\Exception;
 
 use BadMethodCallException;
-use Exception;
+use Throwable;
 
 /**
  * An exception to be thrown when an attempt is made to modify a read-only
@@ -71,17 +71,17 @@ class ReadOnlyException extends BadMethodCallException
     /**
      * Create an exception instance with an attribute's context
      *
-     * @param string $name The name of the attribute attempted to be modified
+     * @param mixed $name The name of the attribute attempted to be modified
      * @param mixed|null $value The value attempted to be set
      * @param int $code The exception code
-     * @param Exception|null $previous A previous exception used for chaining
+     * @param Throwable|null $previous A previous exception used for chaining
      * @return static The newly created exception
      */
     public static function forAttribute(
         $name,
         $value = null,
-        $code = self::CODE_FOR_ATTRIBUTE,
-        Exception $previous = null
+        int $code = self::CODE_FOR_ATTRIBUTE,
+        Throwable $previous = null
     ): self {
         $message = self::DEFAULT_MESSAGE;
 

--- a/src/Incoming/Structure/FixedList.php
+++ b/src/Incoming/Structure/FixedList.php
@@ -8,6 +8,8 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Structure;
 
 use Incoming\Structure\Exception\ReadOnlyException;
@@ -17,8 +19,6 @@ use SplFixedArray;
 use Traversable;
 
 /**
- * FixedList
- *
  * A fixed-size, read-only data-structure
  */
 class FixedList implements StructureInterface
@@ -31,7 +31,7 @@ class FixedList implements StructureInterface
     /**
      * The underlying decorated data structure
      *
-     * @type SplFixedArray
+     * @var SplFixedArray
      */
     private $decorated;
 
@@ -54,9 +54,9 @@ class FixedList implements StructureInterface
      * Create from data in an array
      *
      * @param array $data The data to create from
-     * @return FixedList The resulting data-structure
+     * @return static The resulting data-structure
      */
-    public static function fromArray(array $data)
+    public static function fromArray(array $data): self
     {
         $fixed_list = new static();
 
@@ -69,9 +69,9 @@ class FixedList implements StructureInterface
      * Create from data in a Traversable instance
      *
      * @param Traversable $data The data to create from
-     * @return FixedList The resulting data-structure
+     * @return static The resulting data-structure
      */
-    public static function fromTraversable(Traversable $data)
+    public static function fromTraversable(Traversable $data): self
     {
         return static::fromArray(
             iterator_to_array($data)
@@ -84,7 +84,7 @@ class FixedList implements StructureInterface
      * @param int $index The index to check for existence
      * @return boolean True if the index exists, false otherwise
      */
-    public function exists($index)
+    public function exists($index): bool
     {
         return $this->offsetExists($index);
     }
@@ -110,7 +110,7 @@ class FixedList implements StructureInterface
      *
      * @return boolean True if the list is empty, false otherwise
      */
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return ($this->count() === 0);
     }
@@ -120,7 +120,7 @@ class FixedList implements StructureInterface
      *
      * @return array The array representation of the list
      */
-    public function toArray()
+    public function toArray(): array
     {
         return $this->decorated->toArray();
     }
@@ -130,7 +130,7 @@ class FixedList implements StructureInterface
      *
      * @return int The number of entries in the list
      */
-    public function count()
+    public function count(): int
     {
         return count($this->decorated);
     }
@@ -140,7 +140,7 @@ class FixedList implements StructureInterface
      *
      * @return Iterator An iterator scoped to the list's data
      */
-    public function getIterator()
+    public function getIterator(): Iterator
     {
         return new ReadOnlyIterator(
             $this->decorated
@@ -153,7 +153,7 @@ class FixedList implements StructureInterface
      * @param mixed $offset The offset to check for
      * @return boolean True if the offset exists, false otherwise
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->decorated->offsetExists($offset);
     }

--- a/src/Incoming/Structure/FixedList.php
+++ b/src/Incoming/Structure/FixedList.php
@@ -45,7 +45,7 @@ class FixedList implements StructureInterface
      *
      * @param int $size The size (length) of the list
      */
-    public function __construct($size = 0)
+    public function __construct(int $size = 0)
     {
         $this->decorated = new SplFixedArray($size);
     }
@@ -82,9 +82,9 @@ class FixedList implements StructureInterface
      * Check if a given index exists in the list
      *
      * @param int $index The index to check for existence
-     * @return boolean True if the index exists, false otherwise
+     * return bool True if the index exists, false otherwise
      */
-    public function exists($index): bool
+    public function exists(int $index): bool
     {
         return $this->offsetExists($index);
     }
@@ -96,7 +96,7 @@ class FixedList implements StructureInterface
      * @param mixed $default_val The default value to return if the index does not exist
      * @return mixed The resulting value
      */
-    public function get($index, $default_val = null)
+    public function get(int $index, $default_val = null)
     {
         if ($this->offsetExists($index)) {
             return $this->offsetGet($index);
@@ -108,7 +108,7 @@ class FixedList implements StructureInterface
     /**
      * Check if the list is empty
      *
-     * @return boolean True if the list is empty, false otherwise
+     * return bool True if the list is empty, false otherwise
      */
     public function isEmpty(): bool
     {
@@ -151,7 +151,7 @@ class FixedList implements StructureInterface
      * Check whether an offset exists
      *
      * @param mixed $offset The offset to check for
-     * @return boolean True if the offset exists, false otherwise
+     * return bool True if the offset exists, false otherwise
      */
     public function offsetExists($offset): bool
     {

--- a/src/Incoming/Structure/Iterator/ReadOnlyIterator.php
+++ b/src/Incoming/Structure/Iterator/ReadOnlyIterator.php
@@ -8,13 +8,13 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Structure\Iterator;
 
 use Iterator;
 
 /**
- * ReadOnlyIterator
- *
  * A very basic iterator implementation that decorates another iterator but only
  * allows the most basic of iterator operations without having access to the
  * underlying iterator
@@ -29,7 +29,7 @@ final class ReadOnlyIterator implements Iterator
     /**
      * The underlying decorated iterator
      *
-     * @type Iterator
+     * @var Iterator
      */
     private $decorated;
 
@@ -93,7 +93,7 @@ final class ReadOnlyIterator implements Iterator
      *
      * @return boolean True if the current position is valid, false otherwise
      */
-    public function valid()
+    public function valid(): bool
     {
         return $this->decorated->valid();
     }

--- a/src/Incoming/Structure/Iterator/ReadOnlyIterator.php
+++ b/src/Incoming/Structure/Iterator/ReadOnlyIterator.php
@@ -91,7 +91,7 @@ final class ReadOnlyIterator implements Iterator
     /**
      * Checks if current position is valid
      *
-     * @return boolean True if the current position is valid, false otherwise
+     * return bool True if the current position is valid, false otherwise
      */
     public function valid(): bool
     {

--- a/src/Incoming/Structure/Map.php
+++ b/src/Incoming/Structure/Map.php
@@ -87,8 +87,8 @@ class Map implements StructureInterface
     /**
      * Check if a given key exists in the map
      *
-     * @param string $key The key to check for existence
-     * @return boolean True if the key exists, false otherwise
+     * @param mixed $key The key to check for existence
+     * return bool True if the key exists, false otherwise
      */
     public function exists($key): bool
     {
@@ -98,7 +98,7 @@ class Map implements StructureInterface
     /**
      * Get a value in the map by key
      *
-     * @param string $key The key to get the value for
+     * @param mixed $key The key to get the value for
      * @param mixed $default_val The default value to return if the key does not exist
      * @return mixed The resulting value
      */
@@ -114,7 +114,7 @@ class Map implements StructureInterface
     /**
      * Check if the map is empty
      *
-     * @return boolean True if the map is empty, false otherwise
+     * return bool True if the map is empty, false otherwise
      */
     public function isEmpty(): bool
     {
@@ -169,7 +169,7 @@ class Map implements StructureInterface
      * Check whether an offset exists
      *
      * @param mixed $offset The offset to check for
-     * @return boolean True if the offset exists, false otherwise
+     * return bool True if the offset exists, false otherwise
      */
     public function offsetExists($offset): bool
     {
@@ -220,9 +220,9 @@ class Map implements StructureInterface
      * Allows access to the map's values via object property/field syntax
      *
      * @param string $key The key to check for
-     * @return boolean True if the key exists, false otherwise
+     * return bool True if the key exists, false otherwise
      */
-    public function __isset($key): bool
+    public function __isset(string $key): bool
     {
         return $this->exists($key);
     }
@@ -235,7 +235,7 @@ class Map implements StructureInterface
      * @param string $key The key to get the value for
      * @return mixed The resulting value
      */
-    public function __get($key)
+    public function __get(string $key)
     {
         return $this->get($key);
     }
@@ -249,7 +249,7 @@ class Map implements StructureInterface
      * @throws ReadOnlyException External modification is not allowed
      * @return void
      */
-    public function __set($key, $value)
+    public function __set(string $key, $value)
     {
         throw ReadOnlyException::forAttribute($key, $value);
     }
@@ -262,7 +262,7 @@ class Map implements StructureInterface
      * @throws ReadOnlyException External modification is not allowed
      * @return void
      */
-    public function __unset($key)
+    public function __unset(string $key)
     {
         throw ReadOnlyException::forAttribute($key);
     }

--- a/src/Incoming/Structure/Map.php
+++ b/src/Incoming/Structure/Map.php
@@ -8,6 +8,8 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Structure;
 
 use ArrayIterator;
@@ -19,8 +21,6 @@ use Iterator;
 use Traversable;
 
 /**
- * Map
- *
  * A key => value, read-only map data-structure
  */
 class Map implements StructureInterface
@@ -33,7 +33,7 @@ class Map implements StructureInterface
     /**
      * The underlying decorated data structure
      *
-     * @type ArrayObject
+     * @var ArrayObject
      */
     private $decorated;
 
@@ -54,9 +54,9 @@ class Map implements StructureInterface
      * Create from data in a Traversable instance
      *
      * @param Traversable $data The data to create from
-     * @return Map The resulting data-structure
+     * @return static The resulting data-structure
      */
-    public static function fromTraversable(Traversable $data)
+    public static function fromTraversable(Traversable $data): self
     {
         $map = new static();
 
@@ -75,9 +75,9 @@ class Map implements StructureInterface
      * Create from data in an array
      *
      * @param array $data The data to create from
-     * @return Map The resulting data-structure
+     * @return static The resulting data-structure
      */
-    public static function fromArray(array $data)
+    public static function fromArray(array $data): self
     {
         return static::fromTraversable(
             new ArrayIterator($data)
@@ -90,7 +90,7 @@ class Map implements StructureInterface
      * @param string $key The key to check for existence
      * @return boolean True if the key exists, false otherwise
      */
-    public function exists($key)
+    public function exists($key): bool
     {
         return $this->offsetExists($key);
     }
@@ -116,7 +116,7 @@ class Map implements StructureInterface
      *
      * @return boolean True if the map is empty, false otherwise
      */
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return ($this->count() === 0);
     }
@@ -126,7 +126,7 @@ class Map implements StructureInterface
      *
      * @return array The list of the map's keys
      */
-    public function keys()
+    public function keys(): array
     {
         return array_keys(
             $this->toArray()
@@ -138,7 +138,7 @@ class Map implements StructureInterface
      *
      * @return array The array representation of the map
      */
-    public function toArray()
+    public function toArray(): array
     {
         return $this->decorated->getArrayCopy();
     }
@@ -148,7 +148,7 @@ class Map implements StructureInterface
      *
      * @return int The number of entries in the map
      */
-    public function count()
+    public function count(): int
     {
         return count($this->decorated);
     }
@@ -158,7 +158,7 @@ class Map implements StructureInterface
      *
      * @return Iterator An iterator scoped to the map's data
      */
-    public function getIterator()
+    public function getIterator(): Iterator
     {
         return new ReadOnlyIterator(
             $this->decorated->getIterator()
@@ -171,7 +171,7 @@ class Map implements StructureInterface
      * @param mixed $offset The offset to check for
      * @return boolean True if the offset exists, false otherwise
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->decorated->offsetExists($offset);
     }
@@ -222,7 +222,7 @@ class Map implements StructureInterface
      * @param string $key The key to check for
      * @return boolean True if the key exists, false otherwise
      */
-    public function __isset($key)
+    public function __isset($key): bool
     {
         return $this->exists($key);
     }

--- a/src/Incoming/Structure/StructureFactory.php
+++ b/src/Incoming/Structure/StructureFactory.php
@@ -8,6 +8,8 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Structure;
 
 use ArrayIterator;
@@ -15,8 +17,6 @@ use Incoming\Structure\Exception\InvalidStructuralTypeException;
 use Traversable;
 
 /**
- * StructureFactory
- *
  * A default implementation of the `StructureFactoryInterface` for building
  * the included structural types from loose input data
  */
@@ -29,7 +29,7 @@ class StructureFactory implements StructureFactoryInterface
      * @param mixed $data The input data
      * @return StructureInterface The resulting data-structure
      */
-    public function build($data)
+    public function build($data): StructureInterface
     {
         return static::buildFromTraversableLike($data);
     }
@@ -45,7 +45,7 @@ class StructureFactory implements StructureFactoryInterface
      * @throws InvalidStructuralTypeException If the data type isn't supported
      * @return StructureInterface The built structure
      */
-    protected static function buildFromTraversableLike($data)
+    protected static function buildFromTraversableLike($data): StructureInterface
     {
         if (is_array($data)) {
             return static::buildFromArray($data);
@@ -62,7 +62,7 @@ class StructureFactory implements StructureFactoryInterface
      * @param array $data The input data
      * @return StructureInterface The built structure
      */
-    protected static function buildFromArray(array $data)
+    protected static function buildFromArray(array $data): StructureInterface
     {
         return static::buildFromTraversable(
             new ArrayIterator($data)
@@ -75,7 +75,7 @@ class StructureFactory implements StructureFactoryInterface
      * @param Traversable $data The input data
      * @return StructureInterface The built structure
      */
-    protected static function buildFromTraversable(Traversable $data)
+    protected static function buildFromTraversable(Traversable $data): StructureInterface
     {
         $is_map = false;
 

--- a/src/Incoming/Structure/StructureFactoryInterface.php
+++ b/src/Incoming/Structure/StructureFactoryInterface.php
@@ -24,5 +24,5 @@ interface StructureFactoryInterface
      * @param mixed $data The input data
      * @return StructureInterface The resulting data-structure
      */
-    public function build($data);
+    public function build($data): StructureInterface;
 }

--- a/src/Incoming/Structure/StructureFactoryInterface.php
+++ b/src/Incoming/Structure/StructureFactoryInterface.php
@@ -8,11 +8,11 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Structure;
 
 /**
- * StructureFactoryInterface
- *
  * Defines an interface for building structural data types from a loose input
  */
 interface StructureFactoryInterface

--- a/src/Incoming/Structure/StructureInterface.php
+++ b/src/Incoming/Structure/StructureInterface.php
@@ -8,6 +8,8 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Structure;
 
 use ArrayAccess;
@@ -15,8 +17,6 @@ use Countable;
 use IteratorAggregate;
 
 /**
- * StructureInterface
- *
  * A compound interface defining the external interface of a structure type,
  * which is the union of multiple native data-structure interfaces
  */

--- a/src/Incoming/Transformer/PassthruTransformer.php
+++ b/src/Incoming/Transformer/PassthruTransformer.php
@@ -8,11 +8,11 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Transformer;
 
 /**
- * PassthruTransformer
- *
  * A transformer that simply returns the input data as is
  *
  * Great for use as part of the "Null Object" pattern as its essentially a no-op

--- a/src/Incoming/Transformer/StructureBuilderTransformer.php
+++ b/src/Incoming/Transformer/StructureBuilderTransformer.php
@@ -8,6 +8,8 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Transformer;
 
 use Incoming\Structure\StructureFactory;
@@ -15,8 +17,6 @@ use Incoming\Structure\StructureFactoryInterface;
 use Incoming\Structure\StructureInterface;
 
 /**
- * StructureBuilderTransformer
- *
  * A transformer that takes an input data and returns a StructureInterface
  * representation of the same data
  *
@@ -33,7 +33,7 @@ class StructureBuilderTransformer implements TransformerInterface
     /**
      * The factory used to build the StructureInterface instances
      *
-     * @type StructureFactoryInterface
+     * @var StructureFactoryInterface
      */
     private $structure_factory;
 
@@ -57,7 +57,7 @@ class StructureBuilderTransformer implements TransformerInterface
      *
      * @return StructureFactoryInterface The structure factory
      */
-    public function getStructureFactory()
+    public function getStructureFactory(): StructureFactoryInterface
     {
         return $this->structure_factory;
     }
@@ -66,9 +66,9 @@ class StructureBuilderTransformer implements TransformerInterface
      * Set the structure factory
      *
      * @param StructureFactoryInterface $structure_factory The structure factory
-     * @return StructureBuilderTransformer This instance
+     * @return $this This instance
      */
-    public function setStructureFactory(StructureFactoryInterface $structure_factory)
+    public function setStructureFactory(StructureFactoryInterface $structure_factory): self
     {
         $this->structure_factory = $structure_factory;
 
@@ -81,7 +81,7 @@ class StructureBuilderTransformer implements TransformerInterface
      * @param mixed $input The data to transform
      * @return StructureInterface The transformed data
      */
-    public function transform($input)
+    public function transform($input): StructureInterface
     {
         return $this->structure_factory->build($input);
     }

--- a/src/Incoming/Transformer/TransformerInterface.php
+++ b/src/Incoming/Transformer/TransformerInterface.php
@@ -8,11 +8,11 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Transformer;
 
 /**
- * TransformerInterface
- *
  * Defines an interface used for transforming input data into another state or
  * type
  *

--- a/tests/Incoming/Test/Hydrator/AbstractDelegateHydratorTest.php
+++ b/tests/Incoming/Test/Hydrator/AbstractDelegateHydratorTest.php
@@ -12,14 +12,16 @@ namespace Incoming\Test\Hydrator;
 
 use DateTime;
 use Incoming\Hydrator\AbstractDelegateHydrator;
+use Incoming\Hydrator\Exception\InvalidDelegateException;
 use Incoming\Structure\Map;
 use Incoming\Test\Hydrator\MockDelegateHydrator;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
+use TypeError;
 
 /**
  * AbstractDelegateHydratorTest
  */
-class AbstractDelegateHydratorTest extends PHPUnit_Framework_TestCase
+class AbstractDelegateHydratorTest extends TestCase
 {
 
     /**
@@ -28,7 +30,7 @@ class AbstractDelegateHydratorTest extends PHPUnit_Framework_TestCase
 
     private function getMockDelegateHydrator(callable $delegate)
     {
-        $mock = $this->getMockBuilder('Incoming\Hydrator\AbstractDelegateHydrator')
+        $mock = $this->getMockBuilder(AbstractDelegateHydrator::class)
             ->setMethods([AbstractDelegateHydrator::DEFAULT_DELEGATE_METHOD_NAME])
             ->getMock();
 
@@ -73,23 +75,18 @@ class AbstractDelegateHydratorTest extends PHPUnit_Framework_TestCase
         $this->assertSame($test_input_data['day'], (int) $hydrated->format('j'));
     }
 
-    /**
-     * @expectedException Incoming\Hydrator\Exception\InvalidDelegateException
-     */
     public function testHydrateWithNonCallableThrowsException()
     {
         $mock_hydrator = new MockDelegateHydrator();
+
+        $this->expectException(InvalidDelegateException::class);
 
         $mock_hydrator->hydrate([], new DateTime());
     }
 
     public function testHydrateWithImproperTypesCausesTypeError()
     {
-        if (0 <= version_compare(PHP_VERSION, '7')) {
-            $this->setExpectedException('TypeError');
-        } else {
-            $this->setExpectedException('PHPUnit_Framework_Error');
-        }
+        $this->expectException(TypeError::class);
 
         $test_delegate_callable = function (Map $incoming, DateTime $model) {
         };

--- a/tests/Incoming/Test/Hydrator/AbstractDelegateHydratorTest.php
+++ b/tests/Incoming/Test/Hydrator/AbstractDelegateHydratorTest.php
@@ -8,6 +8,8 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Test\Hydrator;
 
 use DateTime;
@@ -18,9 +20,6 @@ use Incoming\Test\Hydrator\MockDelegateHydrator;
 use PHPUnit\Framework\TestCase;
 use TypeError;
 
-/**
- * AbstractDelegateHydratorTest
- */
 class AbstractDelegateHydratorTest extends TestCase
 {
 

--- a/tests/Incoming/Test/Hydrator/Exception/InvalidDelegateExceptionTest.php
+++ b/tests/Incoming/Test/Hydrator/Exception/InvalidDelegateExceptionTest.php
@@ -8,15 +8,14 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Test\Hydrator\Exception;
 
 use Exception;
 use Incoming\Hydrator\Exception\InvalidDelegateException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * InvalidDelegateExceptionTest
- */
 class InvalidDelegateExceptionTest extends TestCase
 {
 

--- a/tests/Incoming/Test/Hydrator/Exception/InvalidDelegateExceptionTest.php
+++ b/tests/Incoming/Test/Hydrator/Exception/InvalidDelegateExceptionTest.php
@@ -12,20 +12,20 @@ namespace Incoming\Test\Hydrator\Exception;
 
 use Exception;
 use Incoming\Hydrator\Exception\InvalidDelegateException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * InvalidDelegateExceptionTest
  */
-class InvalidDelegateExceptionTest extends PHPUnit_Framework_TestCase
+class InvalidDelegateExceptionTest extends TestCase
 {
 
     public function testForNonCallable()
     {
         $exception = InvalidDelegateException::forNonCallable();
 
-        $this->assertTrue($exception instanceof Exception);
-        $this->assertTrue($exception instanceof InvalidDelegateException);
+        $this->assertInstanceOf(Exception::class, $exception);
+        $this->assertInstanceOf(InvalidDelegateException::class, $exception);
         $this->assertSame(InvalidDelegateException::CODE_FOR_NON_CALLABLE, $exception->getCode());
     }
 
@@ -35,8 +35,8 @@ class InvalidDelegateExceptionTest extends PHPUnit_Framework_TestCase
 
         $exception = InvalidDelegateException::forNonCallable($non_callable_name);
 
-        $this->assertTrue($exception instanceof Exception);
-        $this->assertTrue($exception instanceof InvalidDelegateException);
+        $this->assertInstanceOf(Exception::class, $exception);
+        $this->assertInstanceOf(InvalidDelegateException::class, $exception);
         $this->assertSame(InvalidDelegateException::CODE_FOR_NON_CALLABLE, $exception->getCode());
     }
 
@@ -48,8 +48,8 @@ class InvalidDelegateExceptionTest extends PHPUnit_Framework_TestCase
 
         $exception = InvalidDelegateException::forNonCallable($non_callable_name, $code, $previous);
 
-        $this->assertTrue($exception instanceof Exception);
-        $this->assertTrue($exception instanceof InvalidDelegateException);
+        $this->assertInstanceOf(Exception::class, $exception);
+        $this->assertInstanceOf(InvalidDelegateException::class, $exception);
         $this->assertSame($code, $exception->getCode());
         $this->assertSame($previous, $exception->getPrevious());
     }

--- a/tests/Incoming/Test/Hydrator/Exception/UnresolvableHydratorExceptionTest.php
+++ b/tests/Incoming/Test/Hydrator/Exception/UnresolvableHydratorExceptionTest.php
@@ -13,12 +13,12 @@ namespace Incoming\Test\Hydrator\Exception;
 use DateTime;
 use Exception;
 use Incoming\Hydrator\Exception\UnresolvableHydratorException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * UnresolvableHydratorExceptionTest
  */
-class UnresolvableHydratorExceptionTest extends PHPUnit_Framework_TestCase
+class UnresolvableHydratorExceptionTest extends TestCase
 {
 
     public function testForModel()
@@ -27,8 +27,8 @@ class UnresolvableHydratorExceptionTest extends PHPUnit_Framework_TestCase
 
         $exception = UnresolvableHydratorException::forModel($model);
 
-        $this->assertTrue($exception instanceof Exception);
-        $this->assertTrue($exception instanceof UnresolvableHydratorException);
+        $this->assertInstanceOf(Exception::class, $exception);
+        $this->assertInstanceOf(UnresolvableHydratorException::class, $exception);
         $this->assertSame(UnresolvableHydratorException::CODE_FOR_MODEL, $exception->getCode());
     }
 
@@ -40,8 +40,8 @@ class UnresolvableHydratorExceptionTest extends PHPUnit_Framework_TestCase
 
         $exception = UnresolvableHydratorException::forModel($model, $code, $previous);
 
-        $this->assertTrue($exception instanceof Exception);
-        $this->assertTrue($exception instanceof UnresolvableHydratorException);
+        $this->assertInstanceOf(Exception::class, $exception);
+        $this->assertInstanceOf(UnresolvableHydratorException::class, $exception);
         $this->assertSame($code, $exception->getCode());
         $this->assertSame($previous, $exception->getPrevious());
     }

--- a/tests/Incoming/Test/Hydrator/Exception/UnresolvableHydratorExceptionTest.php
+++ b/tests/Incoming/Test/Hydrator/Exception/UnresolvableHydratorExceptionTest.php
@@ -8,6 +8,8 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Test\Hydrator\Exception;
 
 use DateTime;
@@ -15,9 +17,6 @@ use Exception;
 use Incoming\Hydrator\Exception\UnresolvableHydratorException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * UnresolvableHydratorExceptionTest
- */
 class UnresolvableHydratorExceptionTest extends TestCase
 {
 

--- a/tests/Incoming/Test/Hydrator/HydratorTest.php
+++ b/tests/Incoming/Test/Hydrator/HydratorTest.php
@@ -10,13 +10,14 @@
 
 namespace Incoming\Test\Hydrator;
 
-use PHPUnit_Framework_TestCase;
+use Incoming\Hydrator\HydratorInterface;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * HydratorTest
  */
-class HydratorTest extends PHPUnit_Framework_TestCase
+class HydratorTest extends TestCase
 {
 
     /**
@@ -25,8 +26,7 @@ class HydratorTest extends PHPUnit_Framework_TestCase
 
     private function getMockHydratorForStdClass(array $data, stdClass $instance)
     {
-        $mock = $this->getMockBuilder('Incoming\Hydrator\HydratorInterface')
-            ->getMock();
+        $mock = $this->createMock(HydratorInterface::class);
 
         foreach ($data as $key => $value) {
             $instance->{$key} = $value;

--- a/tests/Incoming/Test/Hydrator/HydratorTest.php
+++ b/tests/Incoming/Test/Hydrator/HydratorTest.php
@@ -8,15 +8,14 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Test\Hydrator;
 
 use Incoming\Hydrator\HydratorInterface;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-/**
- * HydratorTest
- */
 class HydratorTest extends TestCase
 {
 

--- a/tests/Incoming/Test/Hydrator/MockDelegateHydrator.php
+++ b/tests/Incoming/Test/Hydrator/MockDelegateHydrator.php
@@ -8,13 +8,12 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Test\Hydrator;
 
 use Incoming\Hydrator\AbstractDelegateHydrator;
 
-/**
- * MockDelegateHydrator
- */
 class MockDelegateHydrator extends AbstractDelegateHydrator
 {
 }

--- a/tests/Incoming/Test/ProcessorTest.php
+++ b/tests/Incoming/Test/ProcessorTest.php
@@ -8,6 +8,8 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Test;
 
 use Incoming\Hydrator\Exception\UnresolvableHydratorException;
@@ -18,9 +20,6 @@ use Incoming\Transformer\PassthruTransformer;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-/**
- * ProcessorTest
- */
 class ProcessorTest extends TestCase
 {
 

--- a/tests/Incoming/Test/ProcessorTest.php
+++ b/tests/Incoming/Test/ProcessorTest.php
@@ -10,15 +10,18 @@
 
 namespace Incoming\Test;
 
+use Incoming\Hydrator\Exception\UnresolvableHydratorException;
+use Incoming\Hydrator\HydratorFactoryInterface;
+use Incoming\Hydrator\HydratorInterface;
 use Incoming\Processor;
 use Incoming\Transformer\PassthruTransformer;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 
 /**
  * ProcessorTest
  */
-class ProcessorTest extends PHPUnit_Framework_TestCase
+class ProcessorTest extends TestCase
 {
 
     /**
@@ -27,8 +30,7 @@ class ProcessorTest extends PHPUnit_Framework_TestCase
 
     private function getMockHydratorFactory($hydrator_to_return = null)
     {
-        $mock = $this->getMockBuilder('Incoming\Hydrator\HydratorFactoryInterface')
-            ->getMock();
+        $mock = $this->createMock(HydratorFactoryInterface::class);
 
         if (null !== $hydrator_to_return) {
             $mock->expects($this->any())
@@ -41,8 +43,7 @@ class ProcessorTest extends PHPUnit_Framework_TestCase
 
     private function getMockHydratorForStdClass(array $data, stdClass $instance)
     {
-        $mock = $this->getMockBuilder('Incoming\Hydrator\HydratorInterface')
-            ->getMock();
+        $mock = $this->createMock(HydratorInterface::class);
 
         foreach ($data as $key => $value) {
             $instance->{$key} = $value;
@@ -127,9 +128,6 @@ class ProcessorTest extends PHPUnit_Framework_TestCase
         $this->assertSame($test_input_data['misc'], $hydrated->misc);
     }
 
-    /**
-     * @expectedException Incoming\Hydrator\Exception\UnresolvableHydratorException
-     */
     public function testProcessWithUnresolvableHydrator()
     {
         $test_input_data = [
@@ -141,7 +139,8 @@ class ProcessorTest extends PHPUnit_Framework_TestCase
 
         $processor = new Processor();
 
-        // Should throw an exception...
+        $this->expectException(UnresolvableHydratorException::class);
+
         $processor->process($test_input_data, $test_model);
     }
 }

--- a/tests/Incoming/Test/Structure/Exception/InvalidStructuralTypeExceptionTest.php
+++ b/tests/Incoming/Test/Structure/Exception/InvalidStructuralTypeExceptionTest.php
@@ -13,12 +13,12 @@ namespace Incoming\Test\Hydrator\Exception;
 use DateTime;
 use Exception;
 use Incoming\Structure\Exception\InvalidStructuralTypeException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * InvalidStructuralTypeExceptionTest
  */
-class InvalidStructuralTypeExceptionTest extends PHPUnit_Framework_TestCase
+class InvalidStructuralTypeExceptionTest extends TestCase
 {
 
     public function testWithTypeInfo()
@@ -27,8 +27,8 @@ class InvalidStructuralTypeExceptionTest extends PHPUnit_Framework_TestCase
 
         $exception = InvalidStructuralTypeException::withTypeInfo($value);
 
-        $this->assertTrue($exception instanceof Exception);
-        $this->assertTrue($exception instanceof InvalidStructuralTypeException);
+        $this->assertInstanceOf(Exception::class, $exception);
+        $this->assertInstanceOf(InvalidStructuralTypeException::class, $exception);
     }
 
     public function testWithTypeInfoWithExceptionArgs()
@@ -39,8 +39,8 @@ class InvalidStructuralTypeExceptionTest extends PHPUnit_Framework_TestCase
 
         $exception = InvalidStructuralTypeException::withTypeInfo($value, $code, $previous);
 
-        $this->assertTrue($exception instanceof Exception);
-        $this->assertTrue($exception instanceof InvalidStructuralTypeException);
+        $this->assertInstanceOf(Exception::class, $exception);
+        $this->assertInstanceOf(InvalidStructuralTypeException::class, $exception);
         $this->assertSame($code, $exception->getCode());
         $this->assertSame($previous, $exception->getPrevious());
     }

--- a/tests/Incoming/Test/Structure/Exception/InvalidStructuralTypeExceptionTest.php
+++ b/tests/Incoming/Test/Structure/Exception/InvalidStructuralTypeExceptionTest.php
@@ -8,6 +8,8 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Test\Hydrator\Exception;
 
 use DateTime;
@@ -15,9 +17,6 @@ use Exception;
 use Incoming\Structure\Exception\InvalidStructuralTypeException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * InvalidStructuralTypeExceptionTest
- */
 class InvalidStructuralTypeExceptionTest extends TestCase
 {
 

--- a/tests/Incoming/Test/Structure/Exception/ReadOnlyExceptionTest.php
+++ b/tests/Incoming/Test/Structure/Exception/ReadOnlyExceptionTest.php
@@ -12,12 +12,12 @@ namespace Incoming\Test\Hydrator\Exception;
 
 use Exception;
 use Incoming\Structure\Exception\ReadOnlyException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * ReadOnlyExceptionTest
  */
-class ReadOnlyExceptionTest extends PHPUnit_Framework_TestCase
+class ReadOnlyExceptionTest extends TestCase
 {
 
     public function testForAttribute()
@@ -26,8 +26,8 @@ class ReadOnlyExceptionTest extends PHPUnit_Framework_TestCase
 
         $exception = ReadOnlyException::forAttribute($name);
 
-        $this->assertTrue($exception instanceof Exception);
-        $this->assertTrue($exception instanceof ReadOnlyException);
+        $this->assertInstanceOf(Exception::class, $exception);
+        $this->assertInstanceOf(ReadOnlyException::class, $exception);
         $this->assertSame(ReadOnlyException::CODE_FOR_ATTRIBUTE, $exception->getCode());
     }
 
@@ -38,8 +38,8 @@ class ReadOnlyExceptionTest extends PHPUnit_Framework_TestCase
 
         $exception = ReadOnlyException::forAttribute($name, $value);
 
-        $this->assertTrue($exception instanceof Exception);
-        $this->assertTrue($exception instanceof ReadOnlyException);
+        $this->assertInstanceOf(Exception::class, $exception);
+        $this->assertInstanceOf(ReadOnlyException::class, $exception);
         $this->assertSame(ReadOnlyException::CODE_FOR_ATTRIBUTE, $exception->getCode());
     }
 
@@ -52,8 +52,8 @@ class ReadOnlyExceptionTest extends PHPUnit_Framework_TestCase
 
         $exception = ReadOnlyException::forAttribute($name, $value, $code, $previous);
 
-        $this->assertTrue($exception instanceof Exception);
-        $this->assertTrue($exception instanceof ReadOnlyException);
+        $this->assertInstanceOf(Exception::class, $exception);
+        $this->assertInstanceOf(ReadOnlyException::class, $exception);
         $this->assertSame($code, $exception->getCode());
         $this->assertSame($previous, $exception->getPrevious());
     }

--- a/tests/Incoming/Test/Structure/Exception/ReadOnlyExceptionTest.php
+++ b/tests/Incoming/Test/Structure/Exception/ReadOnlyExceptionTest.php
@@ -8,15 +8,14 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Test\Hydrator\Exception;
 
 use Exception;
 use Incoming\Structure\Exception\ReadOnlyException;
 use PHPUnit\Framework\TestCase;
 
-/**
- * ReadOnlyExceptionTest
- */
 class ReadOnlyExceptionTest extends TestCase
 {
 

--- a/tests/Incoming/Test/Structure/FixedListTest.php
+++ b/tests/Incoming/Test/Structure/FixedListTest.php
@@ -11,14 +11,15 @@
 namespace Incoming\Test\Structure;
 
 use ArrayIterator;
+use Incoming\Structure\Exception\ReadOnlyException;
 use Incoming\Structure\FixedList;
 use Iterator;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * FixedListTest
  */
-class FixedListTest extends PHPUnit_Framework_TestCase
+class FixedListTest extends TestCase
 {
 
     /**
@@ -47,7 +48,7 @@ class FixedListTest extends PHPUnit_Framework_TestCase
     {
         $fixed_list = FixedList::fromArray($this->getTestArrayData());
 
-        $this->assertTrue($fixed_list instanceof FixedList);
+        $this->assertInstanceOf(FixedList::class, $fixed_list);
     }
 
     public function testFromTraversable()
@@ -56,7 +57,7 @@ class FixedListTest extends PHPUnit_Framework_TestCase
             new ArrayIterator($this->getTestArrayData())
         );
 
-        $this->assertTrue($fixed_list instanceof FixedList);
+        $this->assertInstanceOf(FixedList::class, $fixed_list);
     }
 
     public function testExists()
@@ -130,7 +131,7 @@ class FixedListTest extends PHPUnit_Framework_TestCase
 
         $fixed_list = FixedList::fromArray($test_data);
 
-        $this->assertTrue($fixed_list->getIterator() instanceof Iterator);
+        $this->assertInstanceOf(Iterator::class, $fixed_list->getIterator());
 
         foreach ($fixed_list->getIterator() as $index => $value) {
             $this->assertSame($test_data[$index], $value);
@@ -162,22 +163,20 @@ class FixedListTest extends PHPUnit_Framework_TestCase
         $this->assertSame($test_data[$test_valid_index], $fixed_list->offsetGet($test_valid_index));
     }
 
-    /**
-     * @expectedException Incoming\Structure\Exception\ReadOnlyException
-     */
     public function testOffsetSet()
     {
         $fixed_list = new FixedList(1);
 
+        $this->expectException(ReadOnlyException::class);
+
         $fixed_list->offsetSet(0, 'test');
     }
 
-    /**
-     * @expectedException Incoming\Structure\Exception\ReadOnlyException
-     */
     public function testOffsetUnset()
     {
         $fixed_list = new FixedList(1);
+
+        $this->expectException(ReadOnlyException::class);
 
         $fixed_list->offsetUnset(0);
     }

--- a/tests/Incoming/Test/Structure/FixedListTest.php
+++ b/tests/Incoming/Test/Structure/FixedListTest.php
@@ -8,6 +8,8 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Test\Structure;
 
 use ArrayIterator;
@@ -16,9 +18,6 @@ use Incoming\Structure\FixedList;
 use Iterator;
 use PHPUnit\Framework\TestCase;
 
-/**
- * FixedListTest
- */
 class FixedListTest extends TestCase
 {
 

--- a/tests/Incoming/Test/Structure/MapTest.php
+++ b/tests/Incoming/Test/Structure/MapTest.php
@@ -11,15 +11,17 @@
 namespace Incoming\Test\Structure;
 
 use ArrayIterator;
+use Incoming\Structure\Exception\ReadOnlyException;
 use Incoming\Structure\Map;
+use InvalidArgumentException;
 use Iterator;
 use MultipleIterator;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * MapTest
  */
-class MapTest extends PHPUnit_Framework_TestCase
+class MapTest extends TestCase
 {
 
     /**
@@ -50,24 +52,18 @@ class MapTest extends PHPUnit_Framework_TestCase
             new ArrayIterator($this->getTestArrayData())
         );
 
-        $this->assertTrue($map instanceof Map);
+        $this->assertInstanceOf(Map::class, $map);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testFromTraversableFailsForNonScalarKeys()
     {
-        if (0 > version_compare(PHP_VERSION, '5.5.0')) {
-            $this->markTestSkipped('PHP 5.5 required to test non-scalar traversable keys');
-        }
-
         $test_iterator = new MultipleIterator();
         $test_iterator->attachIterator(
             new ArrayIterator($this->getTestArrayData())
         );
 
-        // Should throw an exception...
+        $this->expectException(InvalidArgumentException::class);
+
         Map::fromTraversable($test_iterator);
     }
 
@@ -75,7 +71,7 @@ class MapTest extends PHPUnit_Framework_TestCase
     {
         $map = Map::fromArray($this->getTestArrayData());
 
-        $this->assertTrue($map instanceof Map);
+        $this->assertInstanceOf(Map::class, $map);
     }
 
     public function testExists()
@@ -160,7 +156,7 @@ class MapTest extends PHPUnit_Framework_TestCase
 
         $map = Map::fromArray($test_data);
 
-        $this->assertTrue($map->getIterator() instanceof Iterator);
+        $this->assertInstanceOf(Iterator::class, $map->getIterator());
 
         foreach ($map->getIterator() as $key => $value) {
             $this->assertSame($test_data[$key], $value);
@@ -192,22 +188,20 @@ class MapTest extends PHPUnit_Framework_TestCase
         $this->assertSame($test_data[$test_valid_key], $map->offsetGet($test_valid_key));
     }
 
-    /**
-     * @expectedException Incoming\Structure\Exception\ReadOnlyException
-     */
     public function testOffsetSet()
     {
         $map = new Map();
 
+        $this->expectException(ReadOnlyException::class);
+
         $map->offsetSet('some-key', 'test');
     }
 
-    /**
-     * @expectedException Incoming\Structure\Exception\ReadOnlyException
-     */
     public function testOffsetUnset()
     {
         $map = new Map();
+
+        $this->expectException(ReadOnlyException::class);
 
         $map->offsetUnset('some-key');
     }
@@ -237,22 +231,20 @@ class MapTest extends PHPUnit_Framework_TestCase
         $this->assertSame($test_data[$test_valid_key], $map->{$test_valid_key});
     }
 
-    /**
-     * @expectedException Incoming\Structure\Exception\ReadOnlyException
-     */
     public function testMagicSet()
     {
         $map = new Map();
 
+        $this->expectException(ReadOnlyException::class);
+
         $map->key = 'test';
     }
 
-    /**
-     * @expectedException Incoming\Structure\Exception\ReadOnlyException
-     */
     public function testMagicUnset()
     {
         $map = new Map();
+
+        $this->expectException(ReadOnlyException::class);
 
         unset($map->key);
     }

--- a/tests/Incoming/Test/Structure/MapTest.php
+++ b/tests/Incoming/Test/Structure/MapTest.php
@@ -8,6 +8,8 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Test\Structure;
 
 use ArrayIterator;
@@ -18,9 +20,6 @@ use Iterator;
 use MultipleIterator;
 use PHPUnit\Framework\TestCase;
 
-/**
- * MapTest
- */
 class MapTest extends TestCase
 {
 

--- a/tests/Incoming/Test/Structure/StructureFactoryTest.php
+++ b/tests/Incoming/Test/Structure/StructureFactoryTest.php
@@ -12,16 +12,17 @@ namespace Incoming\Test\Structure;
 
 use ArrayIterator;
 use DateTime;
+use Incoming\Structure\Exception\InvalidStructuralTypeException;
 use Incoming\Structure\FixedList;
 use Incoming\Structure\Map;
 use Incoming\Structure\StructureFactory;
 use Incoming\Structure\StructureInterface;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * StructureFactoryTest
  */
-class StructureFactoryTest extends PHPUnit_Framework_TestCase
+class StructureFactoryTest extends TestCase
 {
 
     /**
@@ -71,9 +72,9 @@ class StructureFactoryTest extends PHPUnit_Framework_TestCase
         $structure = (new StructureFactory)->build($data);
 
         // Assert that our types translated correctly
-        $this->assertTrue($structure instanceof FixedList);
+        $this->assertInstanceOf(FixedList::class, $structure);
         $this->assertContainsOnlyInstancesOf('Incoming\Structure\Map', $structure);
-        $this->assertTrue($structure[0]['stuff'] instanceof FixedList);
+        $this->assertInstanceOf(FixedList::class, $structure[0]['stuff']);
     }
 
     public function testBuildWithTraversable()
@@ -83,8 +84,8 @@ class StructureFactoryTest extends PHPUnit_Framework_TestCase
         $structure = (new StructureFactory)->build(new ArrayIterator($data));
 
         // Assert that our types translated correctly
-        $this->assertTrue($structure instanceof Map);
-        $this->assertTrue($structure['stuff'] instanceof FixedList);
+        $this->assertInstanceOf(Map::class, $structure);
+        $this->assertInstanceOf(FixedList::class, $structure['stuff']);
     }
 
     public function testBuildWithNestedArray()
@@ -93,7 +94,7 @@ class StructureFactoryTest extends PHPUnit_Framework_TestCase
 
         $structure = (new StructureFactory)->build($data);
 
-        $this->assertTrue($structure instanceof StructureInterface);
+        $this->assertInstanceOf(StructureInterface::class, $structure);
     }
 
     public function testBuildWithNestedIterators()
@@ -110,15 +111,14 @@ class StructureFactoryTest extends PHPUnit_Framework_TestCase
 
         $structure = (new StructureFactory)->build($data);
 
-        $this->assertTrue($structure instanceof StructureInterface);
+        $this->assertInstanceOf(StructureInterface::class, $structure);
     }
 
-    /**
-     * @expectedException Incoming\Structure\Exception\InvalidStructuralTypeException
-     */
     public function testBuildWithInvalidStructuralType()
     {
         $data = new DateTime();
+
+        $this->expectException(InvalidStructuralTypeException::class);
 
         $structure = (new StructureFactory)->build($data);
     }
@@ -135,6 +135,6 @@ class StructureFactoryTest extends PHPUnit_Framework_TestCase
 
         $structure = (new StructureFactory)->build($data);
 
-        $this->assertTrue($structure instanceof Map);
+        $this->assertInstanceOf(Map::class, $structure);
     }
 }

--- a/tests/Incoming/Test/Structure/StructureFactoryTest.php
+++ b/tests/Incoming/Test/Structure/StructureFactoryTest.php
@@ -8,6 +8,8 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Test\Structure;
 
 use ArrayIterator;
@@ -19,9 +21,6 @@ use Incoming\Structure\StructureFactory;
 use Incoming\Structure\StructureInterface;
 use PHPUnit\Framework\TestCase;
 
-/**
- * StructureFactoryTest
- */
 class StructureFactoryTest extends TestCase
 {
 

--- a/tests/Incoming/Test/Transformer/PassthruTransformerTest.php
+++ b/tests/Incoming/Test/Transformer/PassthruTransformerTest.php
@@ -8,14 +8,13 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Test\Transformer;
 
 use Incoming\Transformer\PassthruTransformer;
 use PHPUnit\Framework\TestCase;
 
-/**
- * PassthruTransformerTest
- */
 class PassthruTransformerTest extends TestCase
 {
 

--- a/tests/Incoming/Test/Transformer/PassthruTransformerTest.php
+++ b/tests/Incoming/Test/Transformer/PassthruTransformerTest.php
@@ -11,12 +11,12 @@
 namespace Incoming\Test\Transformer;
 
 use Incoming\Transformer\PassthruTransformer;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PassthruTransformerTest
  */
-class PassthruTransformerTest extends PHPUnit_Framework_TestCase
+class PassthruTransformerTest extends TestCase
 {
 
     public function testTransform()

--- a/tests/Incoming/Test/Transformer/StructureBuilderTransformerTest.php
+++ b/tests/Incoming/Test/Transformer/StructureBuilderTransformerTest.php
@@ -8,6 +8,8 @@
  * @license   MIT
  */
 
+declare(strict_types=1);
+
 namespace Incoming\Test\Transformer;
 
 use Incoming\Structure\StructureFactory;
@@ -15,9 +17,6 @@ use Incoming\Structure\StructureInterface;
 use Incoming\Transformer\StructureBuilderTransformer;
 use PHPUnit\Framework\TestCase;
 
-/**
- * StructureBuilderTransformerTest
- */
 class StructureBuilderTransformerTest extends TestCase
 {
 

--- a/tests/Incoming/Test/Transformer/StructureBuilderTransformerTest.php
+++ b/tests/Incoming/Test/Transformer/StructureBuilderTransformerTest.php
@@ -13,12 +13,12 @@ namespace Incoming\Test\Transformer;
 use Incoming\Structure\StructureFactory;
 use Incoming\Structure\StructureInterface;
 use Incoming\Transformer\StructureBuilderTransformer;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * StructureBuilderTransformerTest
  */
-class StructureBuilderTransformerTest extends PHPUnit_Framework_TestCase
+class StructureBuilderTransformerTest extends TestCase
 {
 
     public function testGetSetStructureFactory()
@@ -43,6 +43,6 @@ class StructureBuilderTransformerTest extends PHPUnit_Framework_TestCase
 
         $this->assertNotSame($input, $output);
 
-        $this->assertTrue($output instanceof StructureInterface);
+        $this->assertInstanceOf(StructureInterface::class, $output);
     }
 }


### PR DESCRIPTION
This PR upgrades the minimum required version of PHP to `7.0.0`.

This PR is intended to modernize the type-system and features utilized by the library, and to prepare for more upcoming feature improvements to the library.

This PR also does the following, in response of the runtime upgrade:

- Upgrades our development composer packages, to modern versions
- Adds scalar type declarations to parameters, where possible
- Adds return type declarations
- Enables "strict typing" on all files
- Updates some doc-blocks to newer styles (such as `@type` -> `@var`)
- Updates tests to use new features and work with the new testing framework updates